### PR TITLE
Fix Podfile, fix warnings after using "pod install" command and add missing "super.viewDidLoad()" method in "Sample" demo project

### DIFF
--- a/examples/InstaPreview/Podfile
+++ b/examples/InstaPreview/Podfile
@@ -2,4 +2,6 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, "8.0"
 use_frameworks!
 
-pod 'PeekPop', :path => '../..'
+target 'Sample' do
+  pod 'PeekPop', :path => '../..'
+end

--- a/examples/InstaPreview/Sample.xcodeproj/project.pbxproj
+++ b/examples/InstaPreview/Sample.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = "$(inherited)";
 				INFOPLIST_FILE = Sample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -396,7 +396,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = "$(inherited)";
 				INFOPLIST_FILE = Sample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/examples/InstaPreview/Sample/ImagesCollectionViewController.swift
+++ b/examples/InstaPreview/Sample/ImagesCollectionViewController.swift
@@ -18,6 +18,7 @@ class ImagesCollectionViewController: UICollectionViewController, UICollectionVi
     var images = [UIImage(named: "IMG_5441.JPG"), UIImage(named: "IMG_5311.JPG"), UIImage(named: "IMG_5291.JPG"), UIImage(named: "IMG_5290.JPG"), UIImage(named: "IMG_5155.JPG"), UIImage(named: "IMG_5153.JPG"), UIImage(named: "IMG_4976.JPG")]
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         self.title = "InstaPreview"
         self.collectionView!.registerClass(ImageCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
         peekPop = PeekPop(viewController: self)


### PR DESCRIPTION
A command `pod install` should work properly and it will not return warnings:

> [!] The `Sample [Debug]` target overrides the `EMBEDDED_CONTENT_CONTAINS_SWIFT` build setting defined in `Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig'. This can lead to problems with the CocoaPods installation

> [!] The `Sample [Release]` target overrides the `EMBEDDED_CONTENT_CONTAINS_SWIFT` build setting defined in `Pods/Target Support Files/Pods-Sample/Pods-Sample.release.xcconfig'. This can lead to problems with the CocoaPods installation