### PR TITLE
Cancel touches when touch moved in .Possible state

### DIFF
--- a/PeekPop/PeekPopGestureRecognizer.swift
+++ b/PeekPop/PeekPopGestureRecognizer.swift
@@ -56,6 +56,9 @@ class PeekPopGestureRecognizer: UIGestureRecognizer
     override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent)
     {
         super.touchesMoved(touches, withEvent: event)
+        if(self.state == .Possible){
+            self.cancelTouches()
+        }
         if let touch = touches.first where peekPopStarted == true
         {
             testForceChange(touch.majorRadius)


### PR DESCRIPTION
Cancel touches when finger moved before delayedFirstTouch. Without this code there was a posibility of valid touch (through isTouchValid) on larger views. Especially painful on tableViews and collectionViews