### PR TITLE
Fixing objects immediately getting de-initialized

### DIFF
--- a/PeekPop/PeekPop.swift
+++ b/PeekPop/PeekPop.swift
@@ -18,7 +18,7 @@ public class PeekPop: NSObject {
     internal var peekPopGestureRecognizer: PeekPopGestureRecognizer?
     
     /// Fallback to Apple's peek and pop implementation for devices that support it.
-    private weak var forceTouchDelegate: ForceTouchDelegate?
+    private var forceTouchDelegate: ForceTouchDelegate?
     
     //MARK: Lifecycle
     


### PR DESCRIPTION
Sorry about this: my retain cycle fix was causing the objects necessary to have PeekPop work to get de-initialized immediately. I didn't catch this in testing as I didn't clean the project and recompile from scratch in between me setting up my fork and submitting the pull request. Once I cleaned the project and tried to compile it again, it stopped working.

I just checked on both an device with 3D Touch and one without, and this fix makes everything work correctly on both. This should also still fix the retain cycle issue.

Once again, extremely sorry about that, I should have tested more thoroughly.