### PR TITLE
Fix demo gif not displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sadly, almost 80% of iOS users are on older devices.
 
 PeekPop is a Swift framework that brings backwards-compatibility to Peek and Pop.  
 
-<p align="center"><img src="http://i.giphy.com/3o7ablu0adICfQ3OXC.gif" width="242" height="425"/></p>
+<p align="center"><img src="https://cloud.githubusercontent.com/assets/1930855/19472280/3a1e7eac-9559-11e6-93e3-ecc35e60699f.gif" width="242" height="425"/></p>
 
 ## Features
 


### PR DESCRIPTION
The current demo gif image on the README cannot be displayed. This PR fixes the issue by moving the image to GitHub itself.

Note: The image was uploaded to GitHub by creating a new issue on this repo, then drag the image into the page and copy the generated link, then cancel the issue.