### PR TITLE
Update to Swift 3.0, changed screenshot to viewController and lower pressure requirements

### DIFF
--- a/PeekPop.podspec
+++ b/PeekPop.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PeekPop"
-  s.version          = "0.1.5"
+  s.version          = "0.1.6"
   s.summary          = "Backwards-compatible peek and pop."
 
 # This description is used to generate tags and improve search results.

--- a/PeekPop.podspec
+++ b/PeekPop.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PeekPop"
-  s.version          = "0.1.6"
+  s.version          = "0.1.8"
   s.summary          = "Backwards-compatible peek and pop."
 
 # This description is used to generate tags and improve search results.

--- a/PeekPop.xcodeproj/project.pbxproj
+++ b/PeekPop.xcodeproj/project.pbxproj
@@ -177,9 +177,11 @@
 				TargetAttributes = {
 					3453ABA61C7C3B24002768E2 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0810;
 					};
 					3453ABB01C7C3B24002768E2 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0810;
 					};
 				};
 			};
@@ -357,6 +359,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -375,6 +378,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PeekPop;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -385,6 +389,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PeekPopTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -395,6 +400,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.PeekPopTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/PeekPop/ForceTouchDelegate.swift
+++ b/PeekPop/ForceTouchDelegate.swift
@@ -17,13 +17,13 @@ class ForceTouchDelegate: NSObject, UIViewControllerPreviewingDelegate {
         self.delegate = delegate
     }
     
-    func registerFor3DTouch(sourceView: UIView, viewController: UIViewController) {
+    func registerFor3DTouch(_ sourceView: UIView, viewController: UIViewController) {
         if #available(iOS 9.0, *) {
-            viewController.registerForPreviewingWithDelegate(self, sourceView: sourceView)
+            viewController.registerForPreviewing(with: self, sourceView: sourceView)
         }
     }
     
-    @objc func previewingContext(previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+    @objc func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
         if #available(iOS 9.0, *) {
             if let delegate = delegate {
                 let context = PreviewingContext(delegate: delegate, sourceView: previewingContext.sourceView)
@@ -36,7 +36,7 @@ class ForceTouchDelegate: NSObject, UIViewControllerPreviewingDelegate {
         return nil
     }
     
-    @objc func previewingContext(previewingContext: UIViewControllerPreviewing, commitViewController viewControllerToCommit: UIViewController) {
+    @objc func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
         if #available(iOS 9.0, *) {
             if let delegate = delegate {
                 let context = PreviewingContext(delegate: delegate, sourceView: previewingContext.sourceView)

--- a/PeekPop/ForceTouchDelegate.swift
+++ b/PeekPop/ForceTouchDelegate.swift
@@ -40,7 +40,7 @@ class ForceTouchDelegate: NSObject, UIViewControllerPreviewingDelegate {
         if #available(iOS 9.0, *) {
             if let delegate = delegate {
                 let context = PreviewingContext(delegate: delegate, sourceView: previewingContext.sourceView)
-                delegate.previewingContext(context, commitViewController: viewControllerToCommit)
+                delegate.previewingContext(context, commit: viewControllerToCommit)
             }
         }
     }

--- a/PeekPop/Info.plist
+++ b/PeekPop/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PeekPop/Info.plist
+++ b/PeekPop/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.6</string>
+	<string>0.1.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PeekPop/PeekPop.swift
+++ b/PeekPop/PeekPop.swift
@@ -9,16 +9,16 @@
 import Foundation
 
 /// PeekPop class
-public class PeekPop: NSObject {
+open class PeekPop: NSObject {
     
     //MARK: Variables
-    private var previewingContexts = [PreviewingContext]()
+    fileprivate var previewingContexts = [PreviewingContext]()
     
     internal var viewController: UIViewController
     internal var peekPopGestureRecognizer: PeekPopGestureRecognizer?
     
     /// Fallback to Apple's peek and pop implementation for devices that support it.
-    private var forceTouchDelegate: ForceTouchDelegate?
+    fileprivate var forceTouchDelegate: ForceTouchDelegate?
     
     //MARK: Lifecycle
     
@@ -36,7 +36,7 @@ public class PeekPop: NSObject {
     //MARK: Delegate registration
     
     /// Registers a view controller to participate with 3D Touch preview (peek) and commit (pop).
-    public func registerForPreviewingWithDelegate(delegate: PeekPopPreviewingDelegate, sourceView: UIView) -> PreviewingContext {
+    open func registerForPreviewingWithDelegate(_ delegate: PeekPopPreviewingDelegate, sourceView: UIView) -> PreviewingContext {
         let previewing = PreviewingContext(delegate: delegate, sourceView: sourceView)
         previewingContexts.append(previewing)
         
@@ -62,7 +62,7 @@ public class PeekPop: NSObject {
     /// Check whether force touch is available
     func isForceTouchCapable() -> Bool {
         if #available(iOS 9.0, *) {
-            return (self.viewController.traitCollection.forceTouchCapability == UIForceTouchCapability.Available && TARGET_OS_SIMULATOR != 1)
+            return (self.viewController.traitCollection.forceTouchCapability == UIForceTouchCapability.available && TARGET_OS_SIMULATOR != 1)
         }
         return false
     }
@@ -70,13 +70,13 @@ public class PeekPop: NSObject {
 }
 
 /// Previewing context struct
-public class PreviewingContext {
+open class PreviewingContext {
     /// Previewing delegate
-    public weak var delegate: PeekPopPreviewingDelegate?
+    open weak var delegate: PeekPopPreviewingDelegate?
     /// Source view
-    public let sourceView: UIView
+    open let sourceView: UIView
     /// Source rect
-    public var sourceRect: CGRect
+    open var sourceRect: CGRect
     
     init(delegate: PeekPopPreviewingDelegate, sourceView: UIView) {
         self.delegate = delegate
@@ -90,9 +90,9 @@ public class PreviewingContext {
 public protocol PeekPopPreviewingDelegate: class {
     
     /// Provide view controller for previewing context in location. If you return nil, a preview presentation will not be performed.
-    func previewingContext(previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController?
+    func previewingContext(_ previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController?
     
     /// Commit view controller when preview is committed.
-    func previewingContext(previewingContext: PreviewingContext, commitViewController viewControllerToCommit: UIViewController)
+    func previewingContext(_ previewingContext: PreviewingContext, commitViewController viewControllerToCommit: UIViewController)
 }
 

--- a/PeekPop/PeekPop.swift
+++ b/PeekPop/PeekPop.swift
@@ -93,6 +93,6 @@ public protocol PeekPopPreviewingDelegate: class {
     func previewingContext(_ previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController?
     
     /// Commit view controller when preview is committed.
-    func previewingContext(_ previewingContext: PreviewingContext, commitViewController viewControllerToCommit: UIViewController)
+    func previewingContext(_ previewingContext: PreviewingContext, commit viewControllerToCommit: UIViewController)
 }
 

--- a/PeekPop/PeekPopExtensions.swift
+++ b/PeekPop/PeekPopExtensions.swift
@@ -10,23 +10,23 @@ import Foundation
 
 extension UIView {
     
-    func screenshotView(inHierarchy: Bool = true, rect: CGRect? = nil) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(self.layer.frame.size, false, UIScreen.mainScreen().scale);
+    func screenshotView(_ inHierarchy: Bool = true, rect: CGRect? = nil) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(self.layer.frame.size, false, UIScreen.main.scale);
         defer{
             UIGraphicsEndImageContext()
         }
         if inHierarchy == true {
-            self.drawViewHierarchyInRect(self.bounds, afterScreenUpdates: false)
+            self.drawHierarchy(in: self.bounds, afterScreenUpdates: false)
         }
         else {
             if let context = UIGraphicsGetCurrentContext() {
-                self.layer.renderInContext(context)
+                self.layer.render(in: context)
             }
         }
         let image = UIGraphicsGetImageFromCurrentImageContext()
-        let rectTransform = CGAffineTransformMakeScale(image.scale, image.scale)
-        if let rect = rect, let croppedImageRef = CGImageCreateWithImageInRect(image.CGImage, CGRectApplyAffineTransform(rect, rectTransform)) {
-            return UIImage(CGImage: croppedImageRef)
+        let rectTransform = CGAffineTransform(scaleX: (image?.scale)!, y: (image?.scale)!)
+        if let rect = rect, let croppedImageRef = image?.cgImage?.cropping(to: rect.applying(rectTransform)) {
+            return UIImage(cgImage: croppedImageRef)
         }
         else {
             return image
@@ -36,7 +36,7 @@ extension UIView {
 }
 
 extension PeekPop: UIGestureRecognizerDelegate {
-    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
     }
 }

--- a/PeekPop/PeekPopGestureRecognizer.swift
+++ b/PeekPop/PeekPopGestureRecognizer.swift
@@ -10,67 +10,67 @@ import UIKit.UIGestureRecognizerSubclass
 
 class PeekPopGestureRecognizer: UIGestureRecognizer
 {
-    
+
     var context: PreviewingContext?
     let peekPopManager: PeekPopManager
-    
+
     let interpolationSpeed: CGFloat = 0.02
     let previewThreshold: CGFloat = 0.66
     let commitThreshold: CGFloat = 0.99
-    
+
     var progress: CGFloat = 0.0
     var targetProgress: CGFloat = 0.0 {
         didSet { updateProgress() }
     }
-    
+
     var initialMajorRadius: CGFloat = 0.0
     var displayLink: CADisplayLink?
-    
+
     var peekPopStarted = false
-    
+
     //MARK: Lifecycle
-    
+
     init(peekPop: PeekPop) {
         self.peekPopManager = PeekPopManager(peekPop: peekPop)
         super.init(target: nil, action: nil)
     }
-    
+
     //MARK: Touch handling
-    
-    override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent)
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent)
     {
-        super.touchesBegan(touches, withEvent: event)
-        if let touch = touches.first, context = context where isTouchValid(touch)
+        super.touchesBegan(touches, with: event)
+        if let touch = touches.first, let context = context, isTouchValid(touch)
         {
-            let touchLocation = touch.locationInView(self.view)
-            self.state = (context.delegate?.previewingContext(context, viewControllerForLocation: touchLocation) != nil) ? .Possible : .Failed
-            if self.state == .Possible {
-                self.performSelector(#selector(delayedFirstTouch), withObject: touch, afterDelay: 0.2)
+            let touchLocation = touch.location(in: self.view)
+            self.state = (context.delegate?.previewingContext(context, viewControllerForLocation: touchLocation) != nil) ? .possible : .failed
+            if self.state == .possible {
+                self.perform(#selector(delayedFirstTouch), with: touch, afterDelay: 0.2)
             }
         }
         else {
-            self.state = .Failed
+            self.state = .failed
         }
     }
-    
-    override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent)
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent)
     {
-        super.touchesMoved(touches, withEvent: event)
-        if(self.state == .Possible){
+        super.touchesMoved(touches, with: event)
+        if(self.state == .possible){
             self.cancelTouches()
         }
-        if let touch = touches.first where peekPopStarted == true
+        if let touch = touches.first, peekPopStarted == true
         {
             testForceChange(touch.majorRadius)
         }
     }
-    
-    func delayedFirstTouch(touch: UITouch) {
+
+    func delayedFirstTouch(_ touch: UITouch) {
         if isTouchValid(touch) {
-            self.state = .Began
+            self.state = .began
             if let context = context {
-                let touchLocation = touch.locationInView(self.view)
-                peekPopManager.peekPopPossible(context, touchLocation: touchLocation)
+                let touchLocation = touch.location(in: self.view)
+                _ = peekPopManager.peekPopPossible(context, touchLocation: touchLocation)
             }
             peekPopStarted = true
             initialMajorRadius = touch.majorRadius
@@ -78,51 +78,51 @@ class PeekPopGestureRecognizer: UIGestureRecognizer
             targetProgress = previewThreshold
         }
     }
-    
-    func testForceChange(majorRadius: CGFloat) {
+
+    func testForceChange(_ majorRadius: CGFloat) {
         if initialMajorRadius/majorRadius < 0.6  {
             targetProgress = 0.99
         }
     }
-    
-    override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent)
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent)
     {
         self.cancelTouches()
-        super.touchesEnded(touches, withEvent: event)
+        super.touchesEnded(touches, with: event)
     }
-    
-    override func touchesCancelled(touches: Set<UITouch>, withEvent event: UIEvent) {
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
         self.cancelTouches()
-        super.touchesCancelled(touches, withEvent: event)
+        super.touchesCancelled(touches, with: event)
     }
-    
+
     func resetValues() {
-        NSObject.cancelPreviousPerformRequestsWithTarget(self)
+        NSObject.cancelPreviousPerformRequests(withTarget: self)
         peekPopStarted = false
         progress = 0.0
     }
-    
-    private func cancelTouches() {
-        self.state = .Cancelled
+
+    fileprivate func cancelTouches() {
+        self.state = .cancelled
         peekPopStarted = false
-        NSObject.cancelPreviousPerformRequestsWithTarget(self)
+        NSObject.cancelPreviousPerformRequests(withTarget: self)
         if progress < commitThreshold {
             targetProgress = 0.0
         }
     }
-    
-    func isTouchValid(touch: UITouch) -> Bool {
+
+    func isTouchValid(_ touch: UITouch) -> Bool {
         let sourceRect = context?.sourceView.frame ?? CGRect.zero
-        let touchLocation = touch.locationInView(self.view?.superview)
-        return CGRectContainsPoint(sourceRect, touchLocation)
+        let touchLocation = touch.location(in: self.view?.superview)
+        return sourceRect.contains(touchLocation)
     }
-    
+
     func updateProgress() {
         displayLink?.invalidate()
         displayLink = CADisplayLink(target: self, selector: #selector(animateToTargetProgress))
-        displayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
+        displayLink?.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
     }
-    
+
     func animateToTargetProgress() {
         if progress < targetProgress {
             progress = min(progress + interpolationSpeed, targetProgress)
@@ -140,5 +140,5 @@ class PeekPopGestureRecognizer: UIGestureRecognizer
         }
         peekPopManager.animateProgressForContext(progress, context: context)
     }
-    
+
 }

--- a/PeekPop/PeekPopGestureRecognizer.swift
+++ b/PeekPop/PeekPopGestureRecognizer.swift
@@ -15,8 +15,8 @@ class PeekPopGestureRecognizer: UIGestureRecognizer
     let peekPopManager: PeekPopManager
 
     let interpolationSpeed: CGFloat = 0.02
-    let previewThreshold: CGFloat = 0.66
-    let commitThreshold: CGFloat = 0.99
+    let previewThreshold: CGFloat = 0.44
+    let commitThreshold: CGFloat = 0.5
 
     var progress: CGFloat = 0.0
     var targetProgress: CGFloat = 0.0 {
@@ -80,8 +80,8 @@ class PeekPopGestureRecognizer: UIGestureRecognizer
     }
 
     func testForceChange(_ majorRadius: CGFloat) {
-        if initialMajorRadius/majorRadius < 0.6  {
-            targetProgress = 0.99
+        if initialMajorRadius/majorRadius < 0.4  {
+            targetProgress = 0.5
         }
     }
 

--- a/PeekPop/PeekPopManager.swift
+++ b/PeekPop/PeekPopManager.swift
@@ -15,9 +15,9 @@ class PeekPopManager {
     var viewController: UIViewController { get {return peekPop.viewController} }
     var targetViewController: UIViewController?
     
-    private var peekPopView: PeekPopView?
-    private lazy var peekPopWindow: UIWindow = {
-        let window = UIWindow(frame: UIScreen.mainScreen().bounds)
+    fileprivate var peekPopView: PeekPopView?
+    fileprivate lazy var peekPopWindow: UIWindow = {
+        let window = UIWindow(frame: UIScreen.main.bounds)
         window.windowLevel = UIWindowLevelAlert
         window.rootViewController = UIViewController()
         return window
@@ -30,7 +30,7 @@ class PeekPopManager {
     //MARK: PeekPop
     
     /// Prepare peek pop view if peek and pop gesture is possible
-    func peekPopPossible(context: PreviewingContext, touchLocation: CGPoint) -> Bool {
+    func peekPopPossible(_ context: PreviewingContext, touchLocation: CGPoint) -> Bool {
         
         // Return early if no target view controller is provided by delegate method
         guard let targetVC = context.delegate?.previewingContext(context, viewControllerForLocation: touchLocation) else {
@@ -48,9 +48,9 @@ class PeekPopManager {
         }
         
         // Take source view screenshot
-        let rect = viewController.view.convertRect(context.sourceRect, fromView: context.sourceView)
+        let rect = viewController.view.convert(context.sourceRect, from: context.sourceView)
         peekPopView?.sourceViewScreenshot = viewController.view.screenshotView(true, rect: rect)
-        peekPopView?.sourceViewRect = viewController.view.convertRect(rect, toView: nil)
+        peekPopView?.sourceViewRect = viewController.view.convert(rect, to: nil)
 
         // Take target view controller screenshot
         targetVC.view.frame = viewController.view.bounds
@@ -60,7 +60,7 @@ class PeekPopManager {
         return true
     }
     
-    func generateBlurredScreenshots(image: UIImage) -> [UIImage] {
+    func generateBlurredScreenshots(_ image: UIImage) -> [UIImage] {
         var images = [UIImage]()
         images.append(image)
         for i in 1...3 {
@@ -72,25 +72,25 @@ class PeekPopManager {
         return images
     }
     
-    func blurImageWithRadius(image: UIImage, radius: CGFloat) -> UIImage? {
-        return image.applyBlurWithRadius(CGFloat(radius), tintColor: nil, saturationDeltaFactor: 1.0, maskImage: nil)
+    func blurImageWithRadius(_ image: UIImage, radius: CGFloat) -> UIImage? {
+        return image.applyBlur(withRadius: CGFloat(radius), tintColor: nil, saturationDeltaFactor: 1.0, maskImage: nil)
     }
 
     
     /// Add window to heirarchy when peek pop begins
     func peekPopBegan() {
         peekPopWindow.alpha = 0.0
-        peekPopWindow.hidden = false
+        peekPopWindow.isHidden = false
         peekPopWindow.makeKeyAndVisible()
         
         if let peekPopView = peekPopView {
             peekPopWindow.addSubview(peekPopView)
         }
         
-        peekPopView?.frame = UIScreen.mainScreen().bounds
+        peekPopView?.frame = UIScreen.main.bounds
         peekPopView?.didAppear()
         
-        UIView.animateWithDuration(0.2, animations: { () -> Void in
+        UIView.animate(withDuration: 0.2, animations: { () -> Void in
             self.peekPopWindow.alpha = 1.0
         })
         
@@ -102,7 +102,7 @@ class PeekPopManager {
      - parameter progress: A value between 0.0 and 1.0
      - parameter context:  PreviewingContext
      */
-    func animateProgressForContext(progress: CGFloat, context: PreviewingContext?) {
+    func animateProgressForContext(_ progress: CGFloat, context: PreviewingContext?) {
         (progress < 0.99) ? peekPopView?.animateProgress(progress) : commitTarget(context)
     }
     
@@ -111,8 +111,8 @@ class PeekPopManager {
      
      - parameter context: PreviewingContext
      */
-    func commitTarget(context: PreviewingContext?){
-        guard let targetViewController = targetViewController, context = context else {
+    func commitTarget(_ context: PreviewingContext?){
+        guard let targetViewController = targetViewController, let context = context else {
             return
         }
         context.delegate?.previewingContext(context, commitViewController: targetViewController)
@@ -125,14 +125,14 @@ class PeekPopManager {
      - parameter animated: whether or not window removal should be animated
      */
     func peekPopEnded() {
-        UIView.animateWithDuration(0.2, animations: { () -> Void in
+        UIView.animate(withDuration: 0.2, animations: { () -> Void in
             self.peekPopWindow.alpha = 0.0
-            }) { (finished) -> Void in
+            }, completion: { (finished) -> Void in
                 self.peekPop.peekPopGestureRecognizer?.resetValues()
-                self.peekPopWindow.hidden = true
+                self.peekPopWindow.isHidden = true
                 self.peekPopView?.removeFromSuperview()
                 self.peekPopView = nil
-        }
+        }) 
     }
 
 }

--- a/PeekPop/PeekPopManager.swift
+++ b/PeekPop/PeekPopManager.swift
@@ -54,7 +54,7 @@ class PeekPopManager {
 
         // Take target view controller screenshot
         targetVC.view.frame = viewController.view.bounds
-        peekPopView?.targetViewControllerScreenshot = targetVC.view.screenshotView(false)
+        peekPopView?.targetViewControllerView = targetVC.view
         targetViewController = targetVC
         
         return true
@@ -115,6 +115,7 @@ class PeekPopManager {
         guard let targetViewController = targetViewController, let context = context else {
             return
         }
+        peekPopView?.targetViewControllerScreenshot = targetViewController.view.screenshotView(false)
         context.delegate?.previewingContext(context, commitViewController: targetViewController)
         peekPopEnded()
     }

--- a/PeekPop/PeekPopManager.swift
+++ b/PeekPop/PeekPopManager.swift
@@ -103,7 +103,7 @@ class PeekPopManager {
      - parameter context:  PreviewingContext
      */
     func animateProgressForContext(_ progress: CGFloat, context: PreviewingContext?) {
-        (progress < 0.99) ? peekPopView?.animateProgress(progress) : commitTarget(context)
+        (progress < 0.5) ? peekPopView?.animateProgress(progress) : commitTarget(context)
     }
     
     /**
@@ -116,7 +116,7 @@ class PeekPopManager {
             return
         }
         peekPopView?.targetViewControllerScreenshot = targetViewController.view.screenshotView(false)
-        context.delegate?.previewingContext(context, commitViewController: targetViewController)
+        context.delegate?.previewingContext(context, commit: targetViewController)
         peekPopEnded()
     }
     

--- a/PeekPop/PeekPopView.swift
+++ b/PeekPop/PeekPopView.swift
@@ -183,10 +183,11 @@ class PeekPopTargetPreviewView: UIView {
         imageContainer.frame = self.bounds
         imageView.frame = imageViewFrame
         imageView.center = CGPoint(x: self.bounds.size.width / 2, y: self.bounds.size.height / 2)
+
         viewControllerView?.frame = imageViewFrame
-        viewControllerView?.center = CGPoint(x: self.bounds.size.width / 2, y: self.bounds.size.height / 2)
+        viewControllerView?.center.x = (self.bounds.size.width / 2)
     }
-    
+
     func setup() {
         self.addSubview(imageContainer)
         imageContainer.layer.cornerRadius = 15

--- a/PeekPop/PeekPopView.swift
+++ b/PeekPop/PeekPopView.swift
@@ -28,7 +28,12 @@ class PeekPopView: UIView {
             blurredScreenshots.removeAll()
         }
     }
-    var targetViewControllerScreenshot: UIImage? = nil
+    var targetViewControllerView: UIView? = nil
+    var targetViewControllerScreenshot: UIImage? = nil {
+        didSet{
+            targetPreviewView.imageView.image = targetViewControllerScreenshot
+        }
+    }
     var sourceViewScreenshot: UIImage?
     var blurredScreenshots = [UIImage]()
     
@@ -85,7 +90,8 @@ class PeekPopView: UIView {
         targetPreviewView.frame.size = sourceViewRect.size
         targetPreviewView.imageViewFrame = self.bounds
         targetPreviewView.imageView.image = targetViewControllerScreenshot
-   
+        targetPreviewView.viewControllerView = targetViewControllerView
+
         sourceImageView.frame = sourceViewRect
         sourceImageView.image = sourceViewScreenshot
         
@@ -152,6 +158,16 @@ class PeekPopTargetPreviewView: UIView {
     var imageView = UIImageView()
     var imageViewFrame = CGRect.zero
 
+    var viewControllerView: UIView? = nil{
+        willSet{
+            viewControllerView?.removeFromSuperview()
+        }
+        didSet{
+            imageContainer.insertSubview(viewControllerView!, belowSubview: imageView)
+            setNeedsLayout()
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -166,7 +182,9 @@ class PeekPopTargetPreviewView: UIView {
         super.layoutSubviews()
         imageContainer.frame = self.bounds
         imageView.frame = imageViewFrame
-        imageView.center = CGPoint(x: self.bounds.size.width/2, y: self.bounds.size.height/2)
+        imageView.center = CGPoint(x: self.bounds.size.width / 2, y: self.bounds.size.height / 2)
+        viewControllerView?.frame = imageViewFrame
+        viewControllerView?.center = CGPoint(x: self.bounds.size.width / 2, y: self.bounds.size.height / 2)
     }
     
     func setup() {

--- a/PeekPop/PeekPopView.swift
+++ b/PeekPop/PeekPopView.swift
@@ -13,7 +13,7 @@ class PeekPopView: UIView {
     //MARK: Constants
     
     // These are 'magic' values
-    let targePreviewPadding = CGSizeMake(28, 140)
+    let targePreviewPadding = CGSize(width: 28, height: 140)
     
     var sourceViewCenter = CGPoint.zero
     var sourceToCenterXDelta: CGFloat = 0.0
@@ -89,7 +89,7 @@ class PeekPopView: UIView {
         sourceImageView.frame = sourceViewRect
         sourceImageView.image = sourceViewScreenshot
         
-        sourceViewCenter = CGPointMake(sourceViewRect.origin.x + sourceViewRect.size.width/2, sourceViewRect.origin.y + sourceViewRect.size.height/2)
+        sourceViewCenter = CGPoint(x: sourceViewRect.origin.x + sourceViewRect.size.width/2, y: sourceViewRect.origin.y + sourceViewRect.size.height/2)
         sourceToCenterXDelta = self.bounds.size.width/2 - sourceViewCenter.x
         sourceToCenterYDelta = self.bounds.size.height/2 - sourceViewCenter.y
         sourceToTargetWidthDelta = self.bounds.size.width - targePreviewPadding.width - sourceViewRect.size.width
@@ -97,7 +97,7 @@ class PeekPopView: UIView {
 
     }
     
-    func animateProgressiveBlur(progress: CGFloat) {
+    func animateProgressiveBlur(_ progress: CGFloat) {
         if blurredScreenshots.count > 2 {
             let blur = progress*CGFloat(blurredScreenshots.count - 1)
             let blurIndex = Int(blur)
@@ -109,10 +109,10 @@ class PeekPopView: UIView {
         }
     }
     
-    func animateProgress(progress: CGFloat) {
+    func animateProgress(_ progress: CGFloat) {
         
-        sourceImageView.hidden = progress > 0.33
-        targetPreviewView.hidden = progress < 0.33
+        sourceImageView.isHidden = progress > 0.33
+        targetPreviewView.isHidden = progress < 0.33
 
         // Source rect expand stage
         if progress < 0.33 {
@@ -120,21 +120,21 @@ class PeekPopView: UIView {
             animateProgressiveBlur(adjustedProgress)
             let adjustedScale: CGFloat = 1.0 - CGFloat(adjustedProgress)*0.015
             let adjustedSourceImageScale: CGFloat = 1.0 + CGFloat(adjustedProgress)*0.015
-            blurredImageViewFirst.transform = CGAffineTransformMakeScale(adjustedScale, adjustedScale)
-            blurredImageViewSecond.transform = CGAffineTransformMakeScale(adjustedScale, adjustedScale)
+            blurredImageViewFirst.transform = CGAffineTransform(scaleX: adjustedScale, y: adjustedScale)
+            blurredImageViewSecond.transform = CGAffineTransform(scaleX: adjustedScale, y: adjustedScale)
             overlayView.alpha = CGFloat(adjustedProgress)
-            sourceImageView.transform = CGAffineTransformMakeScale(adjustedSourceImageScale, adjustedSourceImageScale)
+            sourceImageView.transform = CGAffineTransform(scaleX: adjustedSourceImageScale, y: adjustedSourceImageScale)
         }
         // Target preview reveal stage
         else if progress < 0.45 {
             let targetAdjustedScale: CGFloat = min(CGFloat((progress - 0.33)/0.1), CGFloat(1.0))
-            targetPreviewView.frame.size = CGSizeMake(sourceViewRect.size.width + sourceToTargetWidthDelta*targetAdjustedScale, sourceViewRect.size.height + sourceToTargetHeightDelta*targetAdjustedScale)
-            targetPreviewView.center = CGPointMake(sourceViewCenter.x + sourceToCenterXDelta*targetAdjustedScale, sourceViewCenter.y + sourceToCenterYDelta*targetAdjustedScale)
+            targetPreviewView.frame.size = CGSize(width: sourceViewRect.size.width + sourceToTargetWidthDelta*targetAdjustedScale, height: sourceViewRect.size.height + sourceToTargetHeightDelta*targetAdjustedScale)
+            targetPreviewView.center = CGPoint(x: sourceViewCenter.x + sourceToCenterXDelta*targetAdjustedScale, y: sourceViewCenter.y + sourceToCenterYDelta*targetAdjustedScale)
         }
         // Target preview expand stage
         else if progress < 0.96 {
             let targetAdjustedScale = min(CGFloat(1 + (progress-0.66)/6),1.1)
-            targetPreviewView.transform = CGAffineTransformMakeScale(targetAdjustedScale, targetAdjustedScale)
+            targetPreviewView.transform = CGAffineTransform(scaleX: targetAdjustedScale, y: targetAdjustedScale)
         }
         // Commit target view controller
         else {
@@ -166,7 +166,7 @@ class PeekPopTargetPreviewView: UIView {
         super.layoutSubviews()
         imageContainer.frame = self.bounds
         imageView.frame = imageViewFrame
-        imageView.center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2)
+        imageView.center = CGPoint(x: self.bounds.size.width/2, y: self.bounds.size.height/2)
     }
     
     func setup() {

--- a/PeekPopTests/Info.plist
+++ b/PeekPopTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PeekPopTests/Info.plist
+++ b/PeekPopTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.6</string>
+	<string>0.1.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/PeekPopTests/PeekPopTests.swift
+++ b/PeekPopTests/PeekPopTests.swift
@@ -10,35 +10,34 @@ import XCTest
 @testable import PeekPop
 
 class PeekPopTests: XCTestCase {
-    
+
     func testGestureRecognizerProgressIncreases() {
         let fakeViewController = UIViewController()
         let peekPop = PeekPop(viewController: fakeViewController)
         let peekPopGestureRecognizer = PeekPopGestureRecognizer(peekPop: peekPop)
         peekPopGestureRecognizer.progress = 0.0
         peekPopGestureRecognizer.targetProgress = 1.0
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+        DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.default).async(execute: {
             sleep(2)
-            dispatch_sync(dispatch_get_main_queue(), {
+            DispatchQueue.main.sync(execute: {
                 XCTAssertEqual(peekPopGestureRecognizer.progress, 1.0)
             })
         })
     }
-    
+
     func testGestureRecognizerProgressDecrease() {
         let fakeViewController = UIViewController()
         let peekPop = PeekPop(viewController: fakeViewController)
         let peekPopGestureRecognizer = PeekPopGestureRecognizer(peekPop: peekPop)
         peekPopGestureRecognizer.progress = 1.0
         peekPopGestureRecognizer.targetProgress = 0.0
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+        DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.default).async(execute: {
             sleep(2)
-            dispatch_sync(dispatch_get_main_queue(), {
+            DispatchQueue.main.sync(execute: {
                 XCTAssertEqual(peekPopGestureRecognizer.progress, 0.0)
             })
         })
     }
 
-    
-    
+
 }

--- a/examples/InstaPreview/Sample.xcodeproj/project.pbxproj
+++ b/examples/InstaPreview/Sample.xcodeproj/project.pbxproj
@@ -195,9 +195,11 @@
 				TargetAttributes = {
 					346EF05C1C954921006FD8A2 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0810;
 					};
 					346EF0701C954921006FD8A2 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0810;
 						TestTargetID = 346EF05C1C954921006FD8A2;
 					};
 				};
@@ -389,6 +391,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -402,6 +405,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -413,6 +417,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.SampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/Sample";
 			};
 			name = Debug;
@@ -425,6 +430,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.SampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sample.app/Sample";
 			};
 			name = Release;

--- a/examples/InstaPreview/Sample/AppDelegate.swift
+++ b/examples/InstaPreview/Sample/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/examples/InstaPreview/Sample/ImagesCollectionViewController.swift
+++ b/examples/InstaPreview/Sample/ImagesCollectionViewController.swift
@@ -20,38 +20,38 @@ class ImagesCollectionViewController: UICollectionViewController, UICollectionVi
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = "InstaPreview"
-        self.collectionView!.registerClass(ImageCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
+        self.collectionView!.register(ImageCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
         peekPop = PeekPop(viewController: self)
         peekPop?.registerForPreviewingWithDelegate(self, sourceView: collectionView!)
     }
 
     // MARK: UICollectionView DataSource and Delegate
 
-    override func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
+    override func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
     }
 
 
-    override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return images.count
     }
 
-    override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCellWithReuseIdentifier(reuseIdentifier, forIndexPath: indexPath)
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
         if let imageCell = cell as? ImageCollectionViewCell {
             imageCell.image = images[indexPath.item]
         }
         return cell
     }
     
-    func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let size = (self.view.bounds.size.width - 5*5)/4
-        return CGSizeMake(size, size)
+        return CGSize(width: size, height: size)
     }
     
-    override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let storyboard = UIStoryboard(name:"Main", bundle:nil)
-        if let previewViewController = storyboard.instantiateViewControllerWithIdentifier("PreviewViewController") as? PreviewViewController {
+        if let previewViewController = storyboard.instantiateViewController(withIdentifier: "PreviewViewController") as? PreviewViewController {
             self.navigationController?.pushViewController(previewViewController, animated: true)
             previewViewController.image = images[indexPath.item]
         }
@@ -60,12 +60,12 @@ class ImagesCollectionViewController: UICollectionViewController, UICollectionVi
     // MARK: PeekPopPreviewingDelegate
     
     
-    func previewingContext(previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController? {
+    func previewingContext(_ previewingContext: PreviewingContext, viewControllerForLocation location: CGPoint) -> UIViewController? {
         let storyboard = UIStoryboard(name:"Main", bundle:nil)
-        if let previewViewController = storyboard.instantiateViewControllerWithIdentifier("PreviewViewController") as? PreviewViewController {
-            if let indexPath = collectionView!.indexPathForItemAtPoint(location) {
+        if let previewViewController = storyboard.instantiateViewController(withIdentifier: "PreviewViewController") as? PreviewViewController {
+            if let indexPath = collectionView!.indexPathForItem(at: location) {
                 let selectedImage = images[indexPath.item]
-                if let layoutAttributes = collectionView!.layoutAttributesForItemAtIndexPath(indexPath) {
+                if let layoutAttributes = collectionView!.layoutAttributesForItem(at: indexPath) {
                     previewingContext.sourceRect = layoutAttributes.frame
                 }
                 previewViewController.image = selectedImage
@@ -76,7 +76,7 @@ class ImagesCollectionViewController: UICollectionViewController, UICollectionVi
         return nil
     }
     
-    func previewingContext(previewingContext: PreviewingContext, commitViewController viewControllerToCommit: UIViewController) {
+    func previewingContext(_ previewingContext: PreviewingContext, commitViewController viewControllerToCommit: UIViewController) {
         self.navigationController?.pushViewController(viewControllerToCommit, animated: false)
     }
 

--- a/examples/InstaPreview/SampleTests/SampleTests.swift
+++ b/examples/InstaPreview/SampleTests/SampleTests.swift
@@ -28,7 +28,7 @@ class SampleTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }


### PR DESCRIPTION
Hi,
I would like to show you some changes in code. I was working with your library and it's fantastic, but also have some drawback.

I implemented showing viewController instead of view's screenshot to let me show viewController and it's loading action. Without this I had barely few things loaded then.

I changed the name of delegate method to suit Swift API guideline.

I saw that in normal cases the gesture you have to make to call commit action is like lying your finger on the screen, so I wanted to lower this requirement and make magic numbers smaller.

It would be nice if you could answer my questions somehow. :)

Great job 👍 